### PR TITLE
Int union constructors

### DIFF
--- a/src/__testfixtures__/union.js
+++ b/src/__testfixtures__/union.js
@@ -31,4 +31,16 @@ var types = XDR.config((xdr) => {
     arms: {},
     defaultArm: xdr.void()
   });
+
+  xdr.union('PaymentResultExt', {
+    switchOn: xdr.int(),
+    switchName: 'v',
+    switches: [
+      [0, xdr.void()],
+      [1, 'errorMsg']
+    ],
+    arms: {
+      errorMsg: xdr.lookup('Error')
+    }
+  });
 });

--- a/src/__tests__/__snapshots__/transform-test.js.snap
+++ b/src/__tests__/__snapshots__/transform-test.js.snap
@@ -1169,5 +1169,38 @@ exports[`.transform(xdr unions) 1`] = `
 
     }
 
+    class PaymentResultExt {
+        constructor(switchValue: 0);
+
+        constructor(switchValue: 1, value: Error);
+
+        switch(): number;
+
+        errorMsg(value?: Error): Error;
+
+        value(): Error | void;
+
+        toXDR(format?: \\"raw\\"): Buffer;
+
+        toXDR(format: \\"hex\\" | \\"base64\\"): string;
+
+        static read(io: Buffer): PaymentResultExt;
+
+        static write(value: PaymentResultExt, io: Buffer): void;
+
+        static isValid(value: PaymentResultExt): boolean;
+
+        static toXDR(value: PaymentResultExt): Buffer;
+
+        static fromXDR(input: Buffer, format?: \\"raw\\"): PaymentResultExt;
+
+        static fromXDR(input: string, format: \\"hex\\" | \\"base64\\"): PaymentResultExt;
+
+        static validateXDR(input: Buffer, format?: \\"raw\\"): boolean;
+
+        static validateXDR(input: string, format: \\"hex\\" | \\"base64\\"): boolean;
+
+    }
+
 }"
 `;

--- a/src/transform.js
+++ b/src/transform.js
@@ -89,9 +89,13 @@ export default function transformer(file, api) {
     return false;
   });
 
-  config.forEach(function(statement) {
+  config.forEach(function (statement) {
+    // TODO: remove this once https://github.com/stellar/xdrgen/issues/152 has been resolved
+    if (statement.type !== 'ExpressionStatement') return;
     const node = statement.expression;
     const callee = node.callee;
+    // TODO: remove this once https://github.com/stellar/xdrgen/issues/152 has been resolved
+    if (!callee) return;
 
     if (
       callee.type === 'MemberExpression' &&
@@ -103,9 +107,11 @@ export default function transformer(file, api) {
   });
 
   // process typedefs first
-  config.forEach(function(statement) {
+  config.forEach(function (statement) {
+    if (statement.type !== 'ExpressionStatement') return;
     const node = statement.expression;
     const callee = node.callee;
+    if (!callee) return;
 
     if (
       callee.type === 'MemberExpression' &&
@@ -117,9 +123,11 @@ export default function transformer(file, api) {
   });
 
   // process structs first
-  config.forEach(function(statement) {
+  config.forEach(function (statement) {
+    if (statement.type !== 'ExpressionStatement') return;
     const node = statement.expression;
     const callee = node.callee;
+    if (!callee) return;
 
     if (
       callee.type === 'MemberExpression' &&
@@ -132,9 +140,11 @@ export default function transformer(file, api) {
   });
 
   // process unions first
-  config.forEach(function(statement) {
+  config.forEach(function (statement) {
+    if (statement.type !== 'ExpressionStatement') return;
     const node = statement.expression;
     const callee = node.callee;
+    if (!callee) return;
 
     if (
       callee.type === 'MemberExpression' &&


### PR DESCRIPTION
## Why
The int discriminated union definitions were not able to be constructed in typescript. The previous method of construction relied on static class methods named after the arm. This fails for int discriminated unions as numbers are not valid method names in Typescript. 

## What
- Adds constructors for each arm for int discriminated unions 
- Fixes type duplication in generated output

Closes #8 